### PR TITLE
New features

### DIFF
--- a/sg_bookmarks.css
+++ b/sg_bookmarks.css
@@ -47,3 +47,34 @@ body>div.___mh_bookmark_outer_container{
 	z-index: 6;
 	width: 380px;
 }
+
+/**New Features 1**/
+.nav__relative-dropdown.___mh_bookmark_outer_container {z-index:1000;}
+.nav__row.__mh_bookmark_item.__mh_state_entered *{opacity:0.7;}
+.nav__row.__mh_bookmark_item.__mh_state_entered.__mh_mid_train .__mh_train_tracks {opacity: 0.17;}
+.nav__row.__mh_bookmark_item.__mh_state_owned {
+	background-image: linear-gradient(#f7edf1 0%, #e6d9de 100%);
+	background-image: -moz-linear-gradient(#f7edf1 0%, #e6d9de 100%);
+	background-image: -webkit-linear-gradient(#f7edf1 0%, #e6d9de 100%);
+}
+.nav__row.__mh_bookmark_item.__mh_state_owned::hover { color: #111; }/*I suspect this is not in effect*/
+
+.nav__row.__mh_bookmark_item.__mh_mid_train{height: 20px;overflow:hidden;}
+.nav__row.__mh_bookmark_item.__mh_mid_train .nav__row__summary__name{white-space: nowrap;}
+.nav__row.__mh_bookmark_item.__mh_mid_train .nav__row__summary__description{display:none;}
+.nav__row.__mh_bookmark_item.__mh_mid_train .__mh_train_tracks {opacity: 0.2; padding: 0px 6px 0px 3px}
+.nav__row.__mh_bookmark_item.__mh_mid_train .__mh_nav_row_img{width:80px;}
+.nav__row i.__mh_train_tracks {
+	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAUCAYAAAC58NwRAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAUFJREFUeNqU0j8oRWEYx/Hz5/pzr0kMVzIYDEQ2pZTFYlZ2i8XAyGC1UWQwMDGIazIok79ZbMpmlCJcJXEd9/o+p99bJ+V07qnPPad7n+c57+99r+953gbG8Yh1fOETP8ihgGn0Ycvno+Zlv95sQgkjeMEuKnpLhAbkMYFu7LnOA2ynTF7FhT0E+iLLsuIaW9ImhvCKucSSXOi8fu/Bcr2hI5uwhEk8Y0VhbVurekMjZtCrLPFVyhD6PBk6hJ/S4KsmfjjBAMo4Vmh30nYOzRhDF47qDf1hDVOYVeh5Ta7oHir0Igax4Dr3sZMyeQ1nLnRBhxOmNOSUpcWWdIcOvOMG33/+fFbYj3ZcJ0PXVBzpXk1kaNKOPlnhKC5xiE4U0YZWTS0q3y2GbW2neNDO3P+ToaxdvAoSoYKU0KHblF8BBgCOtE6kWi9QOAAAAABJRU5ErkJggg==);
+	background-repeat: no-repeat;
+	padding: 0px 4px 0px 4px;
+	height: 20px;
+	width: 12px;
+	background-position: center center;
+	margin: 0 0 0 0;
+}
+.nav__row.__mh_train_end i.__mh_train_tracks {
+	background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAWCAYAAADAQbwGAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAjxJREFUeNqslE1oE1EQx99un2sUkfh9TEIwYhJyEELAxJN4lhIReoqKF0EMIorSo4eCCg0q9tYe9CYIAc1FDwYjEVQIOYmKH4TNwUAxbnFjd9P4fzDbPrZvo4cM/Jg3s7P/nfe12mg0Yp41m03WbrfFMFWv18/XarUZprBSqTSfTCYfY/gln8+zdDq98VAIepTL5Z1ILYIV8egfLINblUrFkDW4/OVOpzMPd5bCLnBpvI/GyxRvp9zVVqtlwd/c1KHjODwajX6lrz8EotttxFNwV4r3g7qoLRQKr+QOdUlYh3nhbfAL2IToblWKf4A7olDTtJE8S52p7bcv1hS1P1UvBgmu+mIH/PHlbNWL3Bevkb8CTCl/mNbtmpQ76K3W/wheCuj8mCI3dg0NOhr3wFsWbC/AAhj4m+K+hd8KyuAR2A0+gj0+sQ/gBI174KSyQ2z/GkwnUa9b1aZNgS1ejThuSkHOuZPJZMRhfQCWwHOwSyEoNuMlHf7rsVjsWeCmJBKJG3BZcIaNt6PEm2w2OxcoOBwOP8Odo0V/D+6LaeVyOY6/0JRt2y7dmlmwF5ymGzX2YF+kDfpG3gmFQjbWeIV2VQh+BzvABem6bu7Qdd1TcNP0+8qD4yLfaDRE9/6rKW7O5V6v9wT+XdCUD8FZkUhk2jCM116+WCyyarXKLMtar+33+zOIFyF4RBbU5D92t9vlKDgQj8dNTHNjXTCtwWDA5FrUMdM0k6lU6lM4HHaUgpMwnU3YJi74V4ABABsT5ipS/d3iAAAAAElFTkSuQmCC');
+	background-repeat: no-repeat;
+	background-position: center center;
+}

--- a/sg_bookmarks.user.js
+++ b/sg_bookmarks.user.js
@@ -31,7 +31,8 @@ var lazyTrainManager = {};//Used to keep track of which giveaways are a train an
 var prevNavRow;
 var navRowIsTrain = false;
 //In order to prevent racing issues, bookmarks are obtained using AJAX. However, this may cause a problem if the user navigates away from the page if the AJAX is not complete yet.
-//queuedBookmarkIds is there to catch these interrupted AJAX requests and ensure the integrity of the bookmarks.
+//queuedBookmarkIds is there to catch these interrupted AJAX requests and ensure the integrity of the bookmarks. Before an AJAX call, the bookmark id is added to this map; after it is done,
+//the ID is removed. If the ID still exists in the map on navigating to a new page, the AJAX call is automatically retried.
 var queuedBookmarkIds = getQueuedBookmarkIds();
 
 //Settings
@@ -76,7 +77,7 @@ function fixDatabase(){
 		if(k===undefined || k === "undefined"){
 			clearBookmark(k);
 		}
-		if(!fixedEntered || data.bookmarks[k] === undefined || Object.keys(data.bookmarks[k]).length===0){
+		if(data.bookmarks[k] === undefined || Object.keys(data.bookmarks[k]).length===0){
 			console.log("Fixing ",k);
 			clearBookmark(k);
 			Giveaways.loadGiveaway(k, function(ga){
@@ -276,6 +277,17 @@ function readCurrentData(){
 
 function saveData(){
 	 GM_setValue("__mh_bookmarks", data);
+}
+//Currently for debugging purposes only
+function exportData(){
+	var exportedData = JSON.stringify(GM_getValue("__mh_bookmarks", ""));
+	console.log(exportedData);
+}
+//exportData();
+function importData(stringData){
+	console.log('importing...');
+	GM_setValue("__mh_bookmarks", JSON.parse(stringData));
+	console.log('importing successful!');
 }
 
 function clearBookmark(gaId){

--- a/sg_bookmarks.user.js
+++ b/sg_bookmarks.user.js
@@ -33,7 +33,7 @@ background-image: -webkit-linear-gradient(#f7edf1 0%, #e6d9de 100%);}");
 //Train classes
 //GM_addStyle(".nav__row.__mh_bookmark_item{padding-bottom:10px}");
 GM_addStyle(".nav__row.__mh_bookmark_item.mid_train{height: 20px;overflow:hidden;margin: 1px 1px 1px 10px;}");
-GM_addStyle(".nav__row.__mh_bookmark_item.mid_train .nav__row__summary__name{text-overflow: ellipsis;white-space: nowrap;overflow: hidden;width: 240px;}");
+GM_addStyle(".nav__row.__mh_bookmark_item.mid_train .nav__row__summary__name{white-space: nowrap;}");
 GM_addStyle(".nav__row.__mh_bookmark_item.mid_train .nav__row__summary__description{display:none;}");
 
 use(SgApi);
@@ -47,6 +47,7 @@ var STATE_NOT_ENTERED = false;
 var STATE_ENTERED = "entered";
 var STATE_OWNED = "owned";//Owned
 var STATE_ENDED = "ended";
+var MAX_BOOKMARK_STR_LENGTH = 39;
 
 function main(){
 	requireDeclaredStyles();
@@ -154,7 +155,11 @@ function addNavRow(bookmarkData){
    var imgUrl = bookmarkData.thumbUrl || getGameThumbUrl(steamAppId);
    var endsAt = moment.unix(ends);
    var hasEnded = endsAt.isBefore(moment());
-   title = title+ " ("+cp+"P)";
+	 var cpstr = " ("+cp+"P)";
+	 if(title.length + cpstr.length > MAX_BOOKMARK_STR_LENGTH) {
+		 title = title.substr(0,MAX_BOOKMARK_STR_LENGTH - cpstr.length) + "…";
+	 }
+   title = title+ cpstr;
    var endsStr = hasEnded ? "ended" : "ends";
    var descr = "by "+creator+" - "+endsStr+" "+endsAt.fromNow();
    var state = STATE_NOT_ENTERED;

--- a/sg_bookmarks.user.js
+++ b/sg_bookmarks.user.js
@@ -49,10 +49,7 @@ height: 20px;\
 width: 12px;\
 background-position: center center;\
 margin: 0 0 0 0;\}");
-GM_addStyle(".nav__row.__mh_train_end i.__mh_train_tracks {background-position: center -9px;}");
-GM_addStyle(".nav__row.__mh_train_start {position:relative;}");
-GM_addStyle(".nav__row.__mh_train_start i.__mh_train_tracks {position:absolute;bottom:0;background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAWCAYAAADAQbwGAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAl5JREFUeNrMVMmOUlEQLYZnIASBMCZMIcDChI7DD/gRunOriRtd9R+o6cT+AP/CjSt3foGrTlgQMIAQZgggMzzPefbFhvcwveiFlVRyc2/VqVPTtem6Lncpdrlj+f8BnSfufdAn0JRF0B20Dv0OHZk82RTqer2W5XLJ8ytoFarjzlKvpQ59TR/6Kpw9w1KpJIFA4DwWi112u13pdDqGoZVomiaRSCQRDoc/DYfD+7D9WCgUxGaz/QV0u90PAHbRarWkWq0aTi6XyxJwsVhIpVKR7XYr8PkwHo+/7Ha7osPh+ANIqsFg8Plms3E2m03xeDySzWYZxBJwPp9LuVwW2oKlE77PgPF+3xRSBcjDyWQiAJVcLkeGV3A6R+RfB2Nht3vS6fQl9KxYLMpsNqPvmanLAL1HpnAwmKE2n1HLr07n4SAwoNfrfQxWF7S93jTNamz0m10HUBjAMdblprBuuAscrax+cg7VCKHjL6EvTsypi42x+gdMgKwnuwx2Gs6aFRqBCHirTSEgCz2dTo0z9RgMjWLapreTKSNVQ3u9ngHM4qs3NiwUCsloNDL0Vp9DIpHgXEo8Hj+oE5nxDrMnqVTq378N6NsVi36/b+z1YDA4SItnslqtVsabCqZ89ynzAUY/mQ7njuundpnpclSUtNttA4x3aj0RvK62yqai1Gq1R8lk8htq5uNHwaIzNaum8PNg+vl8nlsywEY9zWQyV/tdpiDKDxhNwcrHbWANo9GoZZ34ziyYAVcT2dVNKcP5DdKLc+EZSXXxeHgVY9o0Gg3x+/1J/DhvYfeO978FGABB74Vu4zp+rgAAAABJRU5ErkJggg==');\
-background-repeat:no-repeat;width:20px;height:22px;margin-left:1px;opacity:0.8;}");
+GM_addStyle(".nav__row.__mh_train_end i.__mh_train_tracks {background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAWCAYAAADAQbwGAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAjxJREFUeNqslE1oE1EQx99un2sUkfh9TEIwYhJyEELAxJN4lhIReoqKF0EMIorSo4eCCg0q9tYe9CYIAc1FDwYjEVQIOYmKH4TNwUAxbnFjd9P4fzDbPrZvo4cM/Jg3s7P/nfe12mg0Yp41m03WbrfFMFWv18/XarUZprBSqTSfTCYfY/gln8+zdDq98VAIepTL5Z1ILYIV8egfLINblUrFkDW4/OVOpzMPd5bCLnBpvI/GyxRvp9zVVqtlwd/c1KHjODwajX6lrz8EotttxFNwV4r3g7qoLRQKr+QOdUlYh3nhbfAL2IToblWKf4A7olDTtJE8S52p7bcv1hS1P1UvBgmu+mIH/PHlbNWL3Bevkb8CTCl/mNbtmpQ76K3W/wheCuj8mCI3dg0NOhr3wFsWbC/AAhj4m+K+hd8KyuAR2A0+gj0+sQ/gBI174KSyQ2z/GkwnUa9b1aZNgS1ejThuSkHOuZPJZMRhfQCWwHOwSyEoNuMlHf7rsVjsWeCmJBKJG3BZcIaNt6PEm2w2OxcoOBwOP8Odo0V/D+6LaeVyOY6/0JRt2y7dmlmwF5ymGzX2YF+kDfpG3gmFQjbWeIV2VQh+BzvABem6bu7Qdd1TcNP0+8qD4yLfaDRE9/6rKW7O5V6v9wT+XdCUD8FZkUhk2jCM116+WCyyarXKLMtar+33+zOIFyF4RBbU5D92t9vlKDgQj8dNTHNjXTCtwWDA5FrUMdM0k6lU6lM4HHaUgpMwnU3YJi74V4ABABsT5ipS/d3iAAAAAElFTkSuQmCC');background-position: center center;}");
 
 use(SgApi);
 use(Util);
@@ -165,8 +162,8 @@ function addBookmarkMenuItem(title,descr,url,imgUrl,hasEnded,id,state){
 			navRowIsTrain = false;
 			} else {
 				if(lazyTrainManager[descr] === 1) {//Apply "train opening" style to first train giveaway
-					$(prevNavRow).addClass("__mh_train_start");
-					$(prevNavRow).append('<i class="__mh_train_tracks"></i>');
+					//$(prevNavRow).addClass("__mh_train_start");
+					//$(prevNavRow).append('<i class="__mh_train_tracks"></i>');
 				}
 				console.log('t');
 				navRowIsTrain = true;

--- a/sg_bookmarks.user.js
+++ b/sg_bookmarks.user.js
@@ -40,6 +40,7 @@ GM_addStyle(".nav__row.__mh_bookmark_item.mid_train .nav__row__summary__descript
 use(SgApi);
 use(Util);
 
+//GM_setValue("fixedEntered",false);
 var data = new Data();
 var lazyTrainManager = {};//{desc1:1,desc:2,...}
 
@@ -53,7 +54,7 @@ var MAX_BOOKMARK_STR_LENGTH = 39;
 function main(){
 	requireDeclaredStyles();
 	readBookmarks();
-    initSettings();
+  initSettings();
 	fixDatabase();
 	if(isGiveaway()){
 		if(amIBookmarked()) {
@@ -66,15 +67,17 @@ function main(){
 }
 
 function fixDatabase(){
-	if(parseBool(GM_getValue("fixedDb0.7", false)) && GM_getValue("fixedEntered",false)){
+	var fixedEntered = true;//GM_getValue("fixedEntered",false);
+	if(parseBool(GM_getValue("fixedDb0.7", false)) && fixedEntered){
 		return; //already fixed
 	}
 	console.log("Fixing corrupted database...");
 	for(var k in data.bookmarks){
+		//console.log(data.bookmarks);
 		if(k===undefined || k === "undefined"){
 			clearBookmark(k);
 		}
-		if(data.bookmarks[k] === undefined || Object.keys(data.bookmarks[k]).length===0){
+		if(!fixedEntered || data.bookmarks[k] === undefined || Object.keys(data.bookmarks[k]).length===0){
 			console.log("Fixing ",k);
 			clearBookmark(k);
 			Giveaways.loadGiveaway(k, function(ga){
@@ -86,6 +89,7 @@ function fixDatabase(){
 				}catch(e){
 					console.error(e);
 				}
+				//console.log("wtf")
 			});
 		}
 	}

--- a/sg_bookmarks.user.js
+++ b/sg_bookmarks.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SG Bookmarks
 // @namespace    http://steamgifts.com/
-// @version      0.9
+// @version      1.0.0
 // @description  Bookmark giveaways
 // @author       mahermen,crazoter
 // @downloadURL  https://github.com/maherm/steamgifts_scripts/raw/master/sg_bookmarks.user.js
@@ -25,7 +25,7 @@
 //GA Entered classes
 GM_addStyle(".nav__relative-dropdown.___mh_bookmark_outer_container {z-index:1000;}");
 GM_addStyle(".nav__row.__mh_bookmark_item.__mh_state_entered *{opacity:0.7;}");
-GM_addStyle(".nav__row.__mh_bookmark_item.__mh_state_entered.mid_train .train_tracks {opacity: 0.17; padding: 0px 4px 0px 4px}");
+GM_addStyle(".nav__row.__mh_bookmark_item.__mh_state_entered.__mh_mid_train .__mh_train_tracks {opacity: 0.17;}");
 //GM_addStyle(".nav__row.__mh_bookmark_item.__mh_state_entered {background-image: linear-gradient(#f6f6ec 0%, #e9e9ca 100%);background-image: -moz-linear-gradient(#f6f6ec 0%, #e9e9ca 100%);background-image: -webkit-linear-gradient(#f6f6ec 0%, #e9e9ca 100%);}");
 //GA Owned classes
 GM_addStyle(".nav__row.__mh_bookmark_item.__mh_state_owned {background-image: linear-gradient(#f7edf1 0%, #e6d9de 100%);\
@@ -36,18 +36,40 @@ GM_addStyle(".nav__row.__mh_bookmark_item.__mh_state_owned::hover { color: #111;
 //GM_addStyle(".nav__row.__mh_bookmark_item{padding-bottom:10px}");
 //GM_addStyle(".nav__row.__mh_bookmark_item{border-top:1px solid #DDD;}");
 //GM_addStyle(".nav__row.__mh_bookmark_item{z-index:9;position:relative;box-shadow: 0px 1px 5px -1px #ccc;}");
-GM_addStyle(".nav__row.__mh_bookmark_item.mid_train{box-shadow: inset 0 0 10px -9px #000000;height: 20px;overflow:hidden;margin: 0px 0px 0px 2px;}");
-GM_addStyle(".nav__row.__mh_bookmark_item.mid_train .nav__row__summary__name{white-space: nowrap;}");
-GM_addStyle(".nav__row.__mh_bookmark_item.mid_train .nav__row__summary__description{display:none;}");
-GM_addStyle(".nav__row.__mh_bookmark_item.mid_train .train_tracks {opacity: 0.3; padding: 0px 4px 0px 4px}");
-GM_addStyle(".nav__row.__mh_bookmark_item.mid_train .__mh_nav_row_img{width:80px;}");
+GM_addStyle(".nav__row.__mh_bookmark_item.__mh_mid_train{height: 20px;overflow:hidden;}");
+GM_addStyle(".nav__row.__mh_bookmark_item.__mh_mid_train .nav__row__summary__name{white-space: nowrap;}");
+GM_addStyle(".nav__row.__mh_bookmark_item.__mh_mid_train .nav__row__summary__description{display:none;}");
+GM_addStyle(".nav__row.__mh_bookmark_item.__mh_mid_train .__mh_train_tracks {opacity: 0.2; padding: 0px 6px 0px 3px}");
+GM_addStyle(".nav__row.__mh_bookmark_item.__mh_mid_train .__mh_nav_row_img{width:80px;}");
+
+GM_addStyle(".nav__row i.__mh_train_tracks {background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAUCAYAAAC58NwRAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAUFJREFUeNqU0j8oRWEYx/Hz5/pzr0kMVzIYDEQ2pZTFYlZ2i8XAyGC1UWQwMDGIazIok79ZbMpmlCJcJXEd9/o+p99bJ+V07qnPPad7n+c57+99r+953gbG8Yh1fOETP8ihgGn0Ycvno+Zlv95sQgkjeMEuKnpLhAbkMYFu7LnOA2ynTF7FhT0E+iLLsuIaW9ImhvCKucSSXOi8fu/Bcr2hI5uwhEk8Y0VhbVurekMjZtCrLPFVyhD6PBk6hJ/S4KsmfjjBAMo4Vmh30nYOzRhDF47qDf1hDVOYVeh5Ta7oHir0Igax4Dr3sZMyeQ1nLnRBhxOmNOSUpcWWdIcOvOMG33/+fFbYj3ZcJ0PXVBzpXk1kaNKOPlnhKC5xiE4U0YZWTS0q3y2GbW2neNDO3P+ToaxdvAoSoYKU0KHblF8BBgCOtE6kWi9QOAAAAABJRU5ErkJggg==);\
+background-repeat: no-repeat;\
+padding: 0px 4px 0px 4px;\
+height: 20px;\
+width: 12px;\
+background-position: center center;\
+margin: 0 0 0 0;\}");
+GM_addStyle(".nav__row.__mh_train_end i.__mh_train_tracks {background-position: center -9px;}");
+GM_addStyle(".nav__row.__mh_train_start {position:relative;}");
+GM_addStyle(".nav__row.__mh_train_start i.__mh_train_tracks {position:absolute;bottom:0;background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAWCAYAAADAQbwGAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAl5JREFUeNrMVMmOUlEQLYZnIASBMCZMIcDChI7DD/gRunOriRtd9R+o6cT+AP/CjSt3foGrTlgQMIAQZgggMzzPefbFhvcwveiFlVRyc2/VqVPTtem6Lncpdrlj+f8BnSfufdAn0JRF0B20Dv0OHZk82RTqer2W5XLJ8ytoFarjzlKvpQ59TR/6Kpw9w1KpJIFA4DwWi112u13pdDqGoZVomiaRSCQRDoc/DYfD+7D9WCgUxGaz/QV0u90PAHbRarWkWq0aTi6XyxJwsVhIpVKR7XYr8PkwHo+/7Ha7osPh+ANIqsFg8Plms3E2m03xeDySzWYZxBJwPp9LuVwW2oKlE77PgPF+3xRSBcjDyWQiAJVcLkeGV3A6R+RfB2Nht3vS6fQl9KxYLMpsNqPvmanLAL1HpnAwmKE2n1HLr07n4SAwoNfrfQxWF7S93jTNamz0m10HUBjAMdblprBuuAscrax+cg7VCKHjL6EvTsypi42x+gdMgKwnuwx2Gs6aFRqBCHirTSEgCz2dTo0z9RgMjWLapreTKSNVQ3u9ngHM4qs3NiwUCsloNDL0Vp9DIpHgXEo8Hj+oE5nxDrMnqVTq378N6NsVi36/b+z1YDA4SItnslqtVsabCqZ89ynzAUY/mQ7njuundpnpclSUtNttA4x3aj0RvK62yqai1Gq1R8lk8htq5uNHwaIzNaum8PNg+vl8nlsywEY9zWQyV/tdpiDKDxhNwcrHbWANo9GoZZ34ziyYAVcT2dVNKcP5DdKLc+EZSXXxeHgVY9o0Gg3x+/1J/DhvYfeO978FGABB74Vu4zp+rgAAAABJRU5ErkJggg==');\
+background-repeat:no-repeat;width:20px;height:22px;margin-left:1px;opacity:0.8;}");
 
 use(SgApi);
 use(Util);
 
-//GM_setValue("fixedEntered",false);
+//Runtime variables
 var data = new Data();
-var lazyTrainManager = {};//{desc1:1,desc:2,...}
+var lazyTrainManager = {};//Used to keep track of which giveaways are a train and identify the start and end of said trains.Format:{{desc1:String}: {timesOccured:int},{desc2:String}: {timesOccured:int},...}
+var prevNavRow;
+var navRowIsTrain = false;
+
+//Settings
+var SETTINGS_STATES = "Show giveaway status";
+var SETTINGS_TRAIN = "Group giveaways in a train";
+var settings = new Settings("SG_Bookmarks")
+		.boolean("Show giveaway status", true, {description:"Dim entered giveaways and color giveaways you cannot enter.", values: ["No", "Yes"]})
+    .boolean("Group giveaways in a train", true, {description:"Show which giveaways are in the same train.", values: ["No", "Yes"]});
+settings=settings.init({instantSubmit: true,useGmStorage:true});
 
 //CONSTANTS
 var STATE_NOT_ENTERED = "unentered";
@@ -55,6 +77,7 @@ var STATE_ENTERED = "entered";
 var STATE_OWNED = "owned";//Owned
 var STATE_ENDED = "ended";
 var MAX_BOOKMARK_STR_LENGTH = 39;
+
 
 function main(){
 	requireDeclaredStyles();
@@ -122,22 +145,37 @@ function openBookmarkContainer(e){
 }
 
 function addBookmarkMenuItem(title,descr,url,imgUrl,hasEnded,id,state){
-	 var $html = $('<a class="nav__row"></a>');
+	 var $html = $('<a class="nav__row" id="__mh_'+id+'"></a>');
 	$html.addClass("__mh_bookmark_item");
 	 if(hasEnded)
 		 $html.addClass(" __mh_ended");
-	 else if(state) {
+	 else if(settings.get(SETTINGS_STATES) && state) 
 		 $html.addClass("__mh_state_"+state);
-	 }
 	if(url)
 		$html.attr("href",url);
+  if(settings.get(SETTINGS_TRAIN)) {
+	  if(!lazyTrainManager[descr]) {//First time seeing this descript
+			 lazyTrainManager[descr] = 1;
+			console.log(prevNavRow);
+			if(navRowIsTrain && prevNavRow) {//apply "track end" style to last train giveaway
+				$(prevNavRow).addClass("__mh_train_end");
+				console.log("a");
+			}
+			console.log('y');
+			navRowIsTrain = false;
+			} else {
+				if(lazyTrainManager[descr] === 1) {//Apply "train opening" style to first train giveaway
+					$(prevNavRow).addClass("__mh_train_start");
+					$(prevNavRow).append('<i class="__mh_train_tracks"></i>');
+				}
+				console.log('t');
+				navRowIsTrain = true;
+				lazyTrainManager[descr]++;
+				$html.addClass("__mh_mid_train");//I mean, trains are usually by the same person and usually end at the same time
+				$html.append('<i class="__mh_train_tracks"></i>');
+			}
+	}
 	if(imgUrl)
-		if(!lazyTrainManager[descr]) {//First time seeing this descript
-		 lazyTrainManager[descr] = 1;
-		} else {
-			$html.addClass("mid_train");//I mean, trains are usually by the same person and usually end at the same time
-			$html.append('<img class="train_tracks" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAUCAYAAAC58NwRAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAUFJREFUeNqU0j8oRWEYx/Hz5/pzr0kMVzIYDEQ2pZTFYlZ2i8XAyGC1UWQwMDGIazIok79ZbMpmlCJcJXEd9/o+p99bJ+V07qnPPad7n+c57+99r+953gbG8Yh1fOETP8ihgGn0Ycvno+Zlv95sQgkjeMEuKnpLhAbkMYFu7LnOA2ynTF7FhT0E+iLLsuIaW9ImhvCKucSSXOi8fu/Bcr2hI5uwhEk8Y0VhbVurekMjZtCrLPFVyhD6PBk6hJ/S4KsmfjjBAMo4Vmh30nYOzRhDF47qDf1hDVOYVeh5Ta7oHir0Igax4Dr3sZMyeQ1nLnRBhxOmNOSUpcWWdIcOvOMG33/+fFbYj3ZcJ0PXVBzpXk1kaNKOPlnhKC5xiE4U0YZWTS0q3y2GbW2neNDO3P+ToaxdvAoSoYKU0KHblF8BBgCOtE6kWi9QOAAAAABJRU5ErkJggg==">');
-		}
 		$html.append('<img class="__mh_nav_row_img" src="'+imgUrl+'">');
 	var $div = $('<div class="nav__row__summary">');
 	var $titleP = $('<p class="nav__row__summary__name">'+(title?title:"")+'</p>');
@@ -156,6 +194,7 @@ function addBookmarkMenuItem(title,descr,url,imgUrl,hasEnded,id,state){
 		$html.append($remove);
 	}
    $(".__mh_bookmark_container").append($html);
+	 prevNavRow = document.getElementById('__mh_'+id);
 }
 
 function addNavRow(bookmarkData){

--- a/sg_bookmarks.user.js
+++ b/sg_bookmarks.user.js
@@ -22,31 +22,6 @@
 
 /*jshint multistr: true */
 
-//GA Entered classes
-GM_addStyle(".nav__relative-dropdown.___mh_bookmark_outer_container {z-index:1000;}");
-GM_addStyle(".nav__row.__mh_bookmark_item.__mh_state_entered *{opacity:0.7;}");
-GM_addStyle(".nav__row.__mh_bookmark_item.__mh_state_entered.__mh_mid_train .__mh_train_tracks {opacity: 0.17;}");
-//GA Owned classes
-GM_addStyle(".nav__row.__mh_bookmark_item.__mh_state_owned {background-image: linear-gradient(#f7edf1 0%, #e6d9de 100%);\
-background-image: -moz-linear-gradient(#f7edf1 0%, #e6d9de 100%);\
-background-image: -webkit-linear-gradient(#f7edf1 0%, #e6d9de 100%);}");
-GM_addStyle(".nav__row.__mh_bookmark_item.__mh_state_owned::hover { color: #111; }");
-//Train classes
-GM_addStyle(".nav__row.__mh_bookmark_item.__mh_mid_train{height: 20px;overflow:hidden;}");
-GM_addStyle(".nav__row.__mh_bookmark_item.__mh_mid_train .nav__row__summary__name{white-space: nowrap;}");
-GM_addStyle(".nav__row.__mh_bookmark_item.__mh_mid_train .nav__row__summary__description{display:none;}");
-GM_addStyle(".nav__row.__mh_bookmark_item.__mh_mid_train .__mh_train_tracks {opacity: 0.2; padding: 0px 6px 0px 3px}");
-GM_addStyle(".nav__row.__mh_bookmark_item.__mh_mid_train .__mh_nav_row_img{width:80px;}");
-
-GM_addStyle(".nav__row i.__mh_train_tracks {background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAUCAYAAAC58NwRAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAUFJREFUeNqU0j8oRWEYx/Hz5/pzr0kMVzIYDEQ2pZTFYlZ2i8XAyGC1UWQwMDGIazIok79ZbMpmlCJcJXEd9/o+p99bJ+V07qnPPad7n+c57+99r+953gbG8Yh1fOETP8ihgGn0Ycvno+Zlv95sQgkjeMEuKnpLhAbkMYFu7LnOA2ynTF7FhT0E+iLLsuIaW9ImhvCKucSSXOi8fu/Bcr2hI5uwhEk8Y0VhbVurekMjZtCrLPFVyhD6PBk6hJ/S4KsmfjjBAMo4Vmh30nYOzRhDF47qDf1hDVOYVeh5Ta7oHir0Igax4Dr3sZMyeQ1nLnRBhxOmNOSUpcWWdIcOvOMG33/+fFbYj3ZcJ0PXVBzpXk1kaNKOPlnhKC5xiE4U0YZWTS0q3y2GbW2neNDO3P+ToaxdvAoSoYKU0KHblF8BBgCOtE6kWi9QOAAAAABJRU5ErkJggg==);\
-background-repeat: no-repeat;\
-padding: 0px 4px 0px 4px;\
-height: 20px;\
-width: 12px;\
-background-position: center center;\
-margin: 0 0 0 0;\}");
-GM_addStyle(".nav__row.__mh_train_end i.__mh_train_tracks {background:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAWCAYAAADAQbwGAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAjxJREFUeNqslE1oE1EQx99un2sUkfh9TEIwYhJyEELAxJN4lhIReoqKF0EMIorSo4eCCg0q9tYe9CYIAc1FDwYjEVQIOYmKH4TNwUAxbnFjd9P4fzDbPrZvo4cM/Jg3s7P/nfe12mg0Yp41m03WbrfFMFWv18/XarUZprBSqTSfTCYfY/gln8+zdDq98VAIepTL5Z1ILYIV8egfLINblUrFkDW4/OVOpzMPd5bCLnBpvI/GyxRvp9zVVqtlwd/c1KHjODwajX6lrz8EotttxFNwV4r3g7qoLRQKr+QOdUlYh3nhbfAL2IToblWKf4A7olDTtJE8S52p7bcv1hS1P1UvBgmu+mIH/PHlbNWL3Bevkb8CTCl/mNbtmpQ76K3W/wheCuj8mCI3dg0NOhr3wFsWbC/AAhj4m+K+hd8KyuAR2A0+gj0+sQ/gBI174KSyQ2z/GkwnUa9b1aZNgS1ejThuSkHOuZPJZMRhfQCWwHOwSyEoNuMlHf7rsVjsWeCmJBKJG3BZcIaNt6PEm2w2OxcoOBwOP8Odo0V/D+6LaeVyOY6/0JRt2y7dmlmwF5ymGzX2YF+kDfpG3gmFQjbWeIV2VQh+BzvABem6bu7Qdd1TcNP0+8qD4yLfaDRE9/6rKW7O5V6v9wT+XdCUD8FZkUhk2jCM116+WCyyarXKLMtar+33+zOIFyF4RBbU5D92t9vlKDgQj8dNTHNjXTCtwWDA5FrUMdM0k6lU6lM4HHaUgpMwnU3YJi74V4ABABsT5ipS/d3iAAAAAElFTkSuQmCC');background-position: center center;}");
-
 use(SgApi);
 use(Util);
 

--- a/sg_bookmarks.user.js
+++ b/sg_bookmarks.user.js
@@ -22,11 +22,12 @@
 
 /*jshint multistr: true */
 
-//Giveaway Entered classes
+//GA Entered classes
 GM_addStyle(".nav__relative-dropdown.___mh_bookmark_outer_container {z-index:1000;}");
 GM_addStyle(".nav__row.__mh_bookmark_item.__mh_state_entered {background-image: linear-gradient(#f6f6ec 0%, #e9e9ca 100%);\
 background-image: -moz-linear-gradient(#f6f6ec 0%, #e9e9ca 100%);\
 background-image: -webkit-linear-gradient(#f6f6ec 0%, #e9e9ca 100%);}");
+//GA Owned classes
 GM_addStyle(".nav__row.__mh_bookmark_item.__mh_state_owned {background-image: linear-gradient(#f7edf1 0%, #e6d9de 100%);\
 background-image: -moz-linear-gradient(#f7edf1 0%, #e6d9de 100%);\
 background-image: -webkit-linear-gradient(#f7edf1 0%, #e6d9de 100%);}");
@@ -65,7 +66,7 @@ function main(){
 }
 
 function fixDatabase(){
-	if(parseBool(GM_getValue("fixedDb0.7", false))){
+	if(parseBool(GM_getValue("fixedDb0.7", false)) && GM_getValue("fixedEntered",false)){
 		return; //already fixed
 	}
 	console.log("Fixing corrupted database...");
@@ -88,8 +89,11 @@ function fixDatabase(){
 			});
 		}
 	}
+	console.log("Fixed");
 	GM_setValue("fixedDb0.7", true);
+	GM_setValue("fixedEntered",true);
 }
+
 
 function closeBookmarkContainer(){
 	var $button = $('.__mh_bookmark_button');
@@ -269,6 +273,7 @@ function clearBookmark(gaId){
 }
 
 function updateBookmark(entering) {
+  readBookmarks();
 	var gaData = readCurrentData();
 	if(entering) { gaData.isEntered = true; }//assume success
 	else { gaData.isEntered = false; }


### PR DESCRIPTION
+ Colored bookmarks for entered / owned giveaways (CAUTION: DOESN'T ACCOUNT FOR DLCs?)
+ Marked giveaways as train

Descript:
~~Quick and dirty addition.~~

EDIT 2: Program breaking issues should be fixed. Please check and confirm it is so :) Old bookmarks may appear as entered if the user had entered them previously before this update and vice versa; fixDatabase() doesn't work because Giveaways.loadGiveaway never calls the callback...
Further extensive testing indicates this coloring of bookmarks may be somewhat buggy but generally works as intended. Will continue working on it tmr.
~~EDIT: program breaking issues found in new features, do not merge yet~~
~~+ Upon further testing, the code is currently suffering from race issues; the code if a giveaway has been entered is a hit and miss when you refresh the page; works fine on the page itself, but the bookmark may revert after refreshing. Will debug when I get some free time.  I was interacting with multiple bookmarks via multiple tabs... that must have affected the save code because it's currently using only 1 save file. I'll need to change the save method by ensuring the data is updated first before saving.~~
~~+ Old bookmarks may appear as entered if the user had entered them previously before this update and vice versa.~~
~~I've not implemented a database/giveaway check etc. Should be quite straight forward.~~

Possible Issues (No DLC detection):
The only possible issue is that I only used the "isOwned" variable to check if a giveaway is owned and did not account for DLCs before marking the bookmark in red. Minor issue, since very few people, if any, are going to bookmark games that they cannot enter.

Implementation:
I used the descriptions of the bookmarks to identify if they are part of train. Simply put, if their descriptions are the same (by the same user and generally ending in the same time), I assume the giveaways are together. Works pretty good. For the entered/owned giveaways, I simply leveraged on the sgapi and put a click handler on the enter/exit giveaway button. Clicking will automatically trigger the buildNavRows and saving of bookmark data to reflect changes. 

Preview:
![Image](http://i.imgur.com/KbMpiRo.png)

Future optimizations: This was a *really* quick fix so there's some code bloat that shouldn't affect users. The added styles can be edited into the css files and the addBookmarkMenuItem function header can be optimized to remove the "hasEnded" variable amongst other nitpick optimizations. It otherwise works as intended.

EDIT: The ellipsis now cover only the title, leaving the points still visible if a train giveaway bookmark's title gets too long